### PR TITLE
Replace `available` usage with `type -q`

### DIFF
--- a/_python.fish
+++ b/_python.fish
@@ -1,6 +1,6 @@
 # Use python2 if found, otherwise fallback to python.
 function _python
-  if available python2
+  if type -q python2
     python2 $argv
   else
     python $argv


### PR DESCRIPTION
`available` isn't super fishy, let's use `type -q` instead. it's quiet, it avoids redirection, and @derekstavis likes it better :P
